### PR TITLE
Add dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 ## Installation
 - create a pocket application: [https://getpocket.com/developer/apps/new](https://getpocket.com/developer/apps/new) to obtain a `consumerKey`. The application only needs the 'Retrieve' permission.
 
-- Inside cmd/pocket2rm-setup folder: `go build main.go`
-- Inside cmd/pocket2rm folder: `GOOS=linux GOARCH=arm GOARM=7 go build -o pocket2rm.arm`
-- Inside cmd/pocket2rm-reload folder: `GOOS=linux GOARCH=arm GOARM=7 go build -o pocket2rm-reload.arm`
+- Inside cmd/pocket2rm-setup folder: `go get; go build main.go`
+- Inside cmd/pocket2rm folder: `go get; GOOS=linux GOARCH=arm GOARM=7 go build -o pocket2rm.arm`
+- Inside cmd/pocket2rm-reload folder: `go get; GOOS=linux GOARCH=arm GOARM=7 go build -o pocket2rm-reload.arm`
 
 - execute `cmd/pocket2rm-setup/main`
 


### PR DESCRIPTION
I'm using this code on my reMarkable tablet right now, it's great :)

While installing it, I was unsure of how to get all the dependencies for the builds (never used go before), eventually realized you need to run `go get` beforehand.

For non-go devs it might not be obvious that you need to run `go get` before any of the builds in the installation instructions, so this just makes that explicit