### PR TITLE
Easier setup on WSL (CLI only)

### DIFF
--- a/cmd/pocket2rm-setup/main.go
+++ b/cmd/pocket2rm-setup/main.go
@@ -58,6 +58,7 @@ func setup(credentialsPath string) error {
 	authorizationURL := auth.GenerateAuthorizationURL(requestToken, ts.URL)
 
 	open(authorizationURL)
+	fmt.Println("Open Authorization URL: ", authorizationURL)
 
 	<-ch //block until request comes in
 


### PR DESCRIPTION
I am building and running the setup in Windows Subsystem for Linux, so I don't have the ability to open the AuthZ URL in a browser. Printing it to the terminal allows me to copy/paste into a Windows browser.